### PR TITLE
Overloaded metotlarda gelen ambiguous match found hatası için çözüm. 

### DIFF
--- a/Core/Utilities/Interceptors/AspectInterceptorSelector.cs
+++ b/Core/Utilities/Interceptors/AspectInterceptorSelector.cs
@@ -15,8 +15,8 @@ namespace Core.Utilities.Interceptors
         {
             var classAttributes = type.GetCustomAttributes<MethodInterceptionBaseAttribute>
                 (true).ToList();
-            var methodAttributes = type.GetMethod(method.Name)
-                .GetCustomAttributes<MethodInterceptionBaseAttribute>(true);
+            var methodAttributes = type.GetMethod(method.Name, method.GetParameters().Select(p => p.ParameterType).ToArray()).GetCustomAttributes<MethodInterceptionBaseAttribute>(true);
+               
             classAttributes.AddRange(methodAttributes);
             classAttributes.Add(new ExceptionLogAspect(typeof(FileLogger)));
 


### PR DESCRIPTION
Sınıf içinde overloaded metotlar olduğu zaman "ambiguous match found" hatası veriyordu. Metot isminin yanına parametre tiplerine görede arama eklenerek bu hatanın önüne geçildi.