### PR TITLE
isSuccess değişkenine ihtiyaç yok MethodInterception.cs

### DIFF
--- a/Core/Utilities/Interceptors/MethodInterception.cs
+++ b/Core/Utilities/Interceptors/MethodInterception.cs
@@ -13,24 +13,16 @@ namespace Core.Utilities.Interceptors
         protected virtual void OnSuccess(IInvocation invocation) { }
         public override void Intercept(IInvocation invocation)
         {
-            var isSuccess = true;
             OnBefore(invocation);
             try
             {
                 invocation.Proceed();
+                OnSuccess(invocation);
             }
             catch (Exception e)
             {
-                isSuccess = false;
                 OnException(invocation,e);
                 throw;
-            }
-            finally
-            {
-                if (isSuccess)
-                {
-                    OnSuccess(invocation);
-                }
             }
             OnAfter(invocation);
         }


### PR DESCRIPTION
Hata verirse zaten catch bloğuna düşeceğinden ek bir değişken tutmaya gerek yok